### PR TITLE
Sync up constraint version with HOS5.0 release

### DIFF
--- a/eon/api/acl.py
+++ b/eon/api/acl.py
@@ -33,7 +33,7 @@ def register_opts(conf):
 
     :param conf: Eon settings.
     """
-    conf.register_opts(keystone_auth_token._OPTS, group=OPT_GROUP_NAME)
+    conf.register_opts(keystone_auth_token._opts._OPTS, group=OPT_GROUP_NAME)
     keystone_auth_token.CONF = conf
 
 

--- a/tools/pip-requires
+++ b/tools/pip-requires
@@ -15,44 +15,44 @@
 #
 
 setuptools==20.9.0
-pbr>=1.6
-PyMySQL>=0.6.2,!=0.7.7 # MIT License
-SQLAlchemy>=1.0.10,<1.1.0  # MIT
-alembic>=0.8.0
+pbr>=0.6,<1.0
+PyMySQL>=0.6.2 # MIT License
+SQLAlchemy>=0.7.8,<=0.8.99
+alembic>=0.4.1
 amqplib>=0.6.1
 anyjson>=0.3.3
 argparse
-eventlet!=0.18.3,>=0.18.2  # MIT
-kombu>=3.0.25
+eventlet>=0.13.0
+kombu>=2.4.8
 lockfile>=0.8
 lxml>=2.3
 WebOb>=1.2.3
 greenlet==0.4.9
-futures>=3.0
-sqlalchemy-migrate>=0.9.6
-netaddr>=0.7.12,!=0.7.16  # BSD
-paramiko>=1.16.0
-iso8601>=0.1.9
+futures>=2.1.3
+sqlalchemy-migrate>=0.8.2,!=0.8.4
+netaddr>=0.7.6
+paramiko>=1.9.0
+iso8601>=0.1.8
 python-novaclient>=2
 python-neutronclient>=3
 pyvmomi>=6.0.0
-stevedore>=1.5.0
-websockify>=0.6.1
-oslo.rootwrap>=2.0.0 # Apache-2.0
-oslo.concurrency>=3.7.0
+stevedore>=0.14
+websockify>=0.5.1,<0.6
+oslo.rootwrap<1.7.0,>=1.6.0 # Apache-2.0
+oslo.concurrency>=3.0.0
 oslo.config>=3.0.0
-oslo.context>=0.2.0
-oslo.log>=1.14.0
-oslo.messaging>=4.0.0,<=4.6.1 # Apache-2.0
+oslo.context==1.0.0
+oslo.log==2.0.0
+oslo.messaging>=4.0.0 # Apache-2.0
 oslo.versionedobjects>=1.4.0 # Apache-2.0
-oslo.service>=1.0.0
-oslo.utils>=3.5.0
+oslo.service==1.0.0
+oslo.utils==3.0.0
 oslo.db>=4.1.0
 oslo.vmware>=1.16.0
-pecan>=1.0.0
-six>=1.9.0
+pecan>=0.4.5
+six>=1.5.2
 jsonpatch>=1.1
-WSME>=0.8
+WSME>=0.6
 Jinja2
 python-seamicroclient>=0.1.0,<2.0
 PasteDeploy>=1.5.0
@@ -60,13 +60,12 @@ routes>=1.12.3
 httplib2>=0.7.5
 pycrypto>=2.6
 paste>=1.7.4
-passlib>=1.6
-pyOpenSSL>=0.14
+passlib>=1.5.3
+pyOpenSSL>=0.13
 suds==0.4
-Babel>=1.3,!=2.3.0,!=2.3.1,!=2.3.2,!=2.3.3  # BSD
+Babel==1.3
 posix_ipc
-pycadf>=1.1.0,!=2.0.0  # Apache-2.0
+pycadf>=0.4.1,<1.0.0
 ansible==1.9.4
 configparser
 pywinrm==0.1.1
-keystonemiddleware==2.3.4

--- a/tools/test-requires
+++ b/tools/test-requires
@@ -38,6 +38,7 @@ fixtures
 python-subunit>=0.0.18
 testrepository>=0.0.18
 os-testr
+keystonemiddleware==4.9.1
 
 # Optional packages that should be installed when testing
 pysendfile


### PR DESCRIPTION
1. Update pip-requires with the version from HOS5.0
branch(hp/release/newton/5.0 on hp/eon)
2. Update test-requires with needed package(keystonemiddleware). Refer
to the version from upper-constraints.txt in openstack/requirements repo.
3. Fix unit test script in order to run it properly.