### PR TITLE
Fix pep8 errors in eon-repo

### DIFF
--- a/eon/deployer/network/ovsvapp/util/vapp_util.py
+++ b/eon/deployer/network/ovsvapp/util/vapp_util.py
@@ -14,7 +14,6 @@
 # under the License.
 #.
 
-import os
 import subprocess
 
 from concurrent.futures import as_completed

--- a/eon/tests/unit/api/test_acl.py
+++ b/eon/tests/unit/api/test_acl.py
@@ -1,0 +1,34 @@
+#
+# (c) Copyright 2015-2017 Hewlett Packard Enterprise Development Company LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#.
+
+import mock
+from oslo_config import cfg
+
+from eon.api import acl
+from eon.tests.unit import base_test
+
+
+class TestACL(base_test.TestCase):
+
+    def test_install_auth(self):
+        app = mock.MagicMock()
+        public_routes = mock.MagicMock()
+        acl.install_auth(app, cfg.CONF, public_routes)
+
+    def test_install_audit(self):
+        app = mock.MagicMock()
+        public_routes = mock.MagicMock()
+        acl.install_audit(app, cfg.CONF, public_routes)


### PR DESCRIPTION
Fix couple of pep8 errors in eon-repo and add addtional test.

Here's the additional commit message from the original git log.

```
Change-Id: I798f7340719c3f252549d47a66d1a000183f2cbb

commit 671b5684b07a52a6c2aebed59f5a638761145cc8
Author: Swaminathan Vasudevan <svasudevan@hpe.com>
Date: Mon Jul 24 11:15:08 2017 -0700

BUGZILLA-1050302 Fix pep8 errors in eon-repo

Fix couple of pep8 errors in eon-repo

Change-Id: I5c10d62b853bb4050115504dad920581f37089cc
Upstream-fix: None
```