### PR TITLE
EON cluster activation failure.

### DIFF
--- a/eon/deployer/network/ovsvapp/cleanup/cleanup.py
+++ b/eon/deployer/network/ovsvapp/cleanup/cleanup.py
@@ -189,10 +189,25 @@ class Cleanup:
                 cluster['obj'], cluster['name'], False)])
         try:
             eon_env = OVSvAppUtil.get_eon_env(self.inputs.get('neutron'))
-            cmd = ("neutron ovsvapp-cluster-update --vcenter_id %s "
-                   "--clusters %s" % (vcenter_id, cluster_path))
+            os_user_dn = eon_env.get('OS_USER_DOMAIN_NAME')
+            os_project_dn = eon_env.get('OS_PROJECT_DOMAIN_NAME')
+            os_user_name = eon_env.get('OS_USERNAME')
+            os_passwd = eon_env.get('OS_PASSWORD')
+            os_project_name = eon_env.get('OS_PROJECT_NAME')
+            os_auth_url = eon_env.get('OS_AUTH_URL')
+            os_url = eon_env.get('OS_URL')
+            os_token = eon_env.get('OS_TOKEN')
+            cmd = ("neutron --os-user-domain %s --os-project-domain-name %s "
+                   "--os-username %s --os-password %s --os-project-name %s "
+                   "--os-auth-url %s --os-url %s --os-token %s "
+                   "ovsvapp-cluster-update --vcenter_id %s "
+                   "--clusters %s" % (os_user_dn, os_project_dn,
+                                      os_user_name, os_passwd,
+                                      os_project_name, os_auth_url,
+                                      os_url, os_token,
+                                      vcenter_id, cluster_path))
             command = cmd.split(" ")
-            OVSvAppUtil.exec_subprocess(command, eon_env)
+            OVSvAppUtil.exec_subprocess(command)
         except Exception as e:
             LOG.exception(e)
             raise OVSvAppException(_("Error occurred while invoking CLI "

--- a/eon/deployer/network/ovsvapp/install/vapp_installer.py
+++ b/eon/deployer/network/ovsvapp/install/vapp_installer.py
@@ -40,12 +40,28 @@ class VappInstaller:
         try:
             neutron = self.settings.get('neutron')
             eon_env = OVSvAppUtil.get_eon_env(neutron)
-            cmd = ("neutron ovsvapp-cluster-create --vcenter_id %s "
-                   "--clusters %s" % (vcenter_id, cluster_path))
+            os_user_dn = eon_env.get('OS_USER_DOMAIN_NAME')
+            os_project_dn = eon_env.get('OS_PROJECT_DOMAIN_NAME')
+            os_user_name = eon_env.get('OS_USERNAME')
+            os_passwd = eon_env.get('OS_PASSWORD')
+            os_project_name = eon_env.get('OS_PROJECT_NAME')
+            os_auth_url = eon_env.get('OS_AUTH_URL')
+            os_url = eon_env.get('OS_URL')
+            os_token = eon_env.get('OS_TOKEN')
+            cmd = ("neutron --os-user-domain-id %s "
+                   "--os-project-domain-name %s "
+                   "--os-username %s --os-password %s --os-project-name %s "
+                   "--os-auth-url %s --os-url %s --os-token %s "
+                   "ovsvapp-cluster-create --vcenter_id %s "
+                   "--clusters %s" % (os_user_dn, os_project_dn,
+                                      os_user_name, os_passwd,
+                                      os_project_name, os_auth_url,
+                                      os_url, os_token,
+                                      vcenter_id, cluster_path))
             LOG.info("Executing CLI to create cluster-vni allocations: "
                      "{}".format(cmd))
             command = cmd.split(" ")
-            output = OVSvAppUtil.exec_subprocess(command, eon_env)
+            output = OVSvAppUtil.exec_subprocess(command)
             if not output:
                 raise OVSvAppException(
                     "Got empty response while invoking CLI {}".format(cmd))

--- a/eon/deployer/network/ovsvapp/util/vapp_util.py
+++ b/eon/deployer/network/ovsvapp/util/vapp_util.py
@@ -250,11 +250,9 @@ class OVSvAppUtil:
         return my_env
 
     @staticmethod
-    def exec_subprocess(command, env=None):
-        if not env:
-            env = os.environ
+    def exec_subprocess(command):
         output = subprocess.Popen(
-            command, env=env, stdout=subprocess.PIPE).communicate()[0]
+            command, stdout=subprocess.PIPE).communicate()[0]
         LOG.info(output)
         return output
 


### PR DESCRIPTION
EON cluster activation failed with empty response-typo and an invalid
parameter had been passed.

Here's the original commit message.
```
commit 6368898cb33e12b08ff7c60075ee25c55ffdb540
Author: Swaminathan Vasudevan <svasudevan@hpe.com>
Date: Tue Jul 18 17:57:11 2017 -0700

VNETCORE-2966 EON cluster activation fails due to env not passed right

The EON cluster activation fails since the subprocess does not pass
the environment variables properly to neutron.
So in the short term, we will pass in the environment variable as
part of the command itself.

This is with respect to Bugzilla Bug-1047022

Change-Id: I9c9f5da0e5632c85b05456d26f37d90af40d3d06
Upstream-ref: None

commit a2fd38916c73972c336f7b9e9d770b35c623966d
Author: Swaminathan Vasudevan <svasudevan@hpe.com>
Date: Mon Jul 24 11:33:53 2017 -0700

BUGZILLA-1047022 EON cluster activation fails with empty response-typo

The bug was fixed in [1] but it had a typo in the neutron arguments passed
which led to the re-occurence of the issue.
We were not able to catch this error in the unit tests, since the unit
test had issues with the upstream, so we did not run the unit tests on
this repo before this patch merged.

This patch would fix the empty response issue.

[1]: https://review.hpcloud.net/#/c/137478
Upstream-ref: None

Change-Id: I798f7340719c3f252549d47a66d1a000183f2cbb
```